### PR TITLE
Issue 9

### DIFF
--- a/Source/union-miyoomini-toolchain/workspace/retrodex/PokedexActivity_PokemonView_Evolution.cpp
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/PokedexActivity_PokemonView_Evolution.cpp
@@ -307,21 +307,21 @@ bool PokedexActivity_PokemonView_Evolution::renderPokeInfo(SDL_Surface* surf_dis
     /////////////////////////////////////////////////////////////////////////////
     //// Render poke method
     std::string pokeMethod = (*evoChain)[offset + i][4];
-    if (pokeMethod == "level-up" && (*evoChain)[offset + i][5] != "NULL") {
-        pokeMethod = "Lv. " + (*evoChain)[offset + i][5];
+    if (pokeMethod == "Level up" && (*evoChain)[offset + i][5] != "NULL") {
+        pokeMethod += " " + (*evoChain)[offset + i][5];
+    }
+    if (pokeMethod == "Use item") {
+        pokeMethod += " " + (*evoChain)[offset + i][6];
 
     }
-    if (pokeMethod == "use-item") {
-        pokeMethod = "Item:" + (*evoChain)[offset + i][6];
-
-    }
-    if (pokeMethod == "level-up" && (*evoChain)[offset + i][7] != "NULL") {
+    if (pokeMethod == "Level up" && (*evoChain)[offset + i][7] != "NULL") {
         pokeMethod = "Time: " + (*evoChain)[offset + i][7];
-
+        if ((*evoChain)[offset + i][8] != "NULL") {
+            pokeMethod += " Happiness: " + (*evoChain)[offset + i][8];
+        }
     }
-    if (pokeMethod == "level-up" && (*evoChain)[offset + i][8] != "NULL") {
+    else if (pokeMethod == "Level up" && (*evoChain)[offset + i][8] != "NULL") {
         pokeMethod = "Happiness: " + (*evoChain)[offset + i][8];
-
     }
     SDL_Surface* pokeMethodSurface = TTF_RenderUTF8_Blended(
         font,
@@ -336,10 +336,10 @@ bool PokedexActivity_PokemonView_Evolution::renderPokeInfo(SDL_Surface* surf_dis
     SDL_Rect pokeMethodRect;
     pokeMethodRect.x = pokeNameRect.x;
     pokeMethodRect.y = pokeNameRect.y + pokeNameRect.h + 10;
-    pokeMethodRect.w = static_cast<int>(pokeMethodSurface->w);
-    pokeMethodRect.h = static_cast<int>(pokeMethodSurface->h);
+    pokeMethodRect.w = static_cast<int>(pokeMethodSurface->w * .9);
+    pokeMethodRect.h = static_cast<int>(pokeMethodSurface->h * .9);
 
-    PokeSurface::onDraw(surf_display, pokeMethodSurface, &pokeMethodRect);
+    PokeSurface::onDrawScaled(surf_display, pokeMethodSurface, &pokeMethodRect);
     SDL_FreeSurface(pokeMethodSurface);
 
     

--- a/Source/window_dev/PokedexActivity_PokemonView_Evolution.cpp
+++ b/Source/window_dev/PokedexActivity_PokemonView_Evolution.cpp
@@ -307,21 +307,21 @@ bool PokedexActivity_PokemonView_Evolution::renderPokeInfo(SDL_Surface* surf_dis
     /////////////////////////////////////////////////////////////////////////////
     //// Render poke method
     std::string pokeMethod = (*evoChain)[offset + i][4];
-    if (pokeMethod == "level-up" && (*evoChain)[offset + i][5] != "NULL") {
-        pokeMethod = "Lv. " + (*evoChain)[offset + i][5];
+    if (pokeMethod == "Level up" && (*evoChain)[offset + i][5] != "NULL") {
+        pokeMethod += " " + (*evoChain)[offset + i][5];
+    }
+    if (pokeMethod == "Use item") {
+        pokeMethod += " " + (*evoChain)[offset + i][6];
 
     }
-    if (pokeMethod == "use-item") {
-        pokeMethod = "Item:" + (*evoChain)[offset + i][6];
-
-    }
-    if (pokeMethod == "level-up" && (*evoChain)[offset + i][7] != "NULL") {
+    if (pokeMethod == "Level up" && (*evoChain)[offset + i][7] != "NULL") {
         pokeMethod = "Time: " + (*evoChain)[offset + i][7];
-
+        if ((*evoChain)[offset + i][8] != "NULL") {
+            pokeMethod += " Happiness: " + (*evoChain)[offset + i][8];
+        }
     }
-    if (pokeMethod == "level-up" && (*evoChain)[offset + i][8] != "NULL") {
+    else if (pokeMethod == "Level up" && (*evoChain)[offset + i][8] != "NULL") {
         pokeMethod = "Happiness: " + (*evoChain)[offset + i][8];
-
     }
     SDL_Surface* pokeMethodSurface = TTF_RenderUTF8_Blended(
         font,
@@ -336,10 +336,10 @@ bool PokedexActivity_PokemonView_Evolution::renderPokeInfo(SDL_Surface* surf_dis
     SDL_Rect pokeMethodRect;
     pokeMethodRect.x = pokeNameRect.x;
     pokeMethodRect.y = pokeNameRect.y + pokeNameRect.h + 10;
-    pokeMethodRect.w = static_cast<int>(pokeMethodSurface->w);
-    pokeMethodRect.h = static_cast<int>(pokeMethodSurface->h);
+    pokeMethodRect.w = static_cast<int>(pokeMethodSurface->w * .9);
+    pokeMethodRect.h = static_cast<int>(pokeMethodSurface->h * .9);
 
-    PokeSurface::onDraw(surf_display, pokeMethodSurface, &pokeMethodRect);
+    PokeSurface::onDrawScaled(surf_display, pokeMethodSurface, &pokeMethodRect);
     SDL_FreeSurface(pokeMethodSurface);
 
     


### PR DESCRIPTION
Attempt to address issue #9, evolution method query not filtering by `language_id`, all evo method showing in English. 

### This cannot be accomplished.
**Merging these changes which support English by default, but more than happy to open another issue to try and resolve this.**  

The database does not support / is missing entries in the `evolution_trigger_prose` table corresponding to other languages. It really only has support for `language_id` 9 ( English) ... 
```
evolution_trigger_prose table

evolution_trigger_id	**local_language_id**	name
1	**5**	Montée de niveau
2	**5**	Échange
3	**5**	Utilisation d'un objet
4	**5**	Place dans l'équipe et une Poké Ball
1	**6**	Levelaufstieg
2	**6**	Tausch
3	**6**	Gegenstand nutzen
4	**6**	Platz im Team und ein Pokéball
1	**9**	Level up
2	**9**	Trade
3	**9**	Use item
4	**9**	Shed
5	**9**	Spin
6	**9**	Train in the Tower of Darkness
7	**9**	Train in the Tower of Waters
8	**9**	Land three critical hits in a battle
9	**9**	Go somewhere after taking damage
```
This really makes me think I'm going to have to drop the multi language support. At this point the options are:

- [ ] Leave it as is. Support other languages where we can, print English where we can't. Not pretty but it will work.
- [ ] Fill in the missing data to support other languages. Almost certainly a large task that would involve data mining. No. 
- [ ] Use Icons instead of printing characters. Ex. for evolutions we could use rare candy, items, and other icons to signify the method. 


The miyoo mini and many other retro handhelds are manufactured in China. I would imagine there is a big user base from that region. I would like to be able to support that language but it's one of the languages with little support in the database..