### PR TITLE
Feat:Craeting github action/workflow

### DIFF
--- a/.github/workflows/place_holder.yml
+++ b/.github/workflows/place_holder.yml
@@ -1,0 +1,24 @@
+name: Placeholder Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - jenkins
+      - refactor
+      - issue_**
+      - prod**
+      - dev**
+      - release**
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Placeholder Test
+        run: |
+          echo "Running placeholder test..."
+          exit 0


### PR DESCRIPTION
 Github is warning about not having proper branch permissions. When trying to enable I come across option to Require branches to be up to date before merging. But to enable this option a workflow is needed inorder to get a status check. Not sure why it works this way, and not just allow me to define wether I want the requirement or not without the workflow but oh well. I might need more time and practice with premissions.