### PR TITLE
Issue 53

### DIFF
--- a/Source/union-miyoomini-toolchain/workspace/retrodex/Pokedex.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/Pokedex.cc
@@ -52,11 +52,25 @@ int Pokedex::onExecute() {
         return -1;
     }
 
-    SDL_Event event;
+	Uint32 prev_ButtonPressTick;
+	static SDL_Event event;
     while (running) {
-    	while (SDL_PollEvent(&event)) {
-        	onEvent(&event);
+		while(SDL_PollEvent(&event)){
+			prev_ButtonPressTick = SDL_GetTicks();
+
+			onEvent(&event);
 		}
+
+		Uint32 cur_ButtonPressTick = SDL_GetTicks();
+		Uint32 elapsedTime = cur_ButtonPressTick - prev_ButtonPressTick;
+		if(elapsedTime >= 150){
+			//SDL_PumpEvents();
+			static const Uint8* currentKeyStates = SDL_GetKeyboardState(NULL);
+			PokedexActivityManager::onKeyHold(currentKeyStates, &event);
+
+			prev_ButtonPressTick = cur_ButtonPressTick;
+		}
+
         onLoop();
         onRender();
     }

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/Pokedex.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/Pokedex.cc
@@ -63,7 +63,7 @@ int Pokedex::onExecute() {
 
 		Uint32 cur_ButtonPressTick = SDL_GetTicks();
 		Uint32 elapsedTime = cur_ButtonPressTick - prev_ButtonPressTick;
-		if(elapsedTime >= 150){
+		if(elapsedTime >= 100){
 			//SDL_PumpEvents();
 			static const Uint8* currentKeyStates = SDL_GetKeyboardState(NULL);
 			PokedexActivityManager::onKeyHold(currentKeyStates, &event);

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/PokedexActivityEvent.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/PokedexActivityEvent.cc
@@ -8,125 +8,63 @@ PokedexActivityEvent::~PokedexActivityEvent() {
 }
 
 void PokedexActivityEvent::onEvent(SDL_Event* event) {
-	SDL_Keycode key = event->key.keysym.sym;
-
-	switch (event->type) {
-	case SDL_QUIT:
-	case SDLK_ESCAPE:
+	if (event->type == SDL_QUIT || event->key.keysym.sym == SW_BTN_MENU || event->type == SDL_SYSWMEVENT ){
 		onExit();
-	break;
-	case SDL_KEYDOWN:
-		std::cout << "Keydown" << std::endl;
-		if(keystates[key] != RELEASED){
-			keystates[key] = REPEATING;
-			onKeyHold(key, event->key.keysym.mod);
-			std::cout << "called onKeyHold" << std::endl;
+	}
+	else if (event->type == SDL_KEYDOWN) {
+		switch(event->key.keysym.sym){
+		case SW_BTN_UP:
+			onButtonUp(SW_BTN_UP, event->key.keysym.mod);
+			break;
+		case SW_BTN_DOWN:
+			onButtonDown(SW_BTN_DOWN, event->key.keysym.mod);
+			break;
+		case SW_BTN_LEFT:
+			onButtonLeft(SW_BTN_LEFT, event->key.keysym.mod);
+			break;
+		case SW_BTN_RIGHT:
+			onButtonRight(SW_BTN_RIGHT, event->key.keysym.mod);
+			break;
+		case SW_BTN_A:
+			onButtonA(SW_BTN_A, event->key.keysym.mod);
+			break;
+		case SW_BTN_B:
+			onButtonB(SW_BTN_B, event->key.keysym.mod);
+			break;
+		case SW_BTN_X:
+			onButtonX(SW_BTN_X, event->key.keysym.mod);
+			break;
+		case SW_BTN_Y:
+			onButtonY(SW_BTN_Y, event->key.keysym.mod);
+			break;
+		case SW_BTN_START:
+			onButtonStart(SW_BTN_START, event->key.keysym.mod);
+			break;
+		case SW_BTN_SELECT:
+			onButtonSelect(SW_BTN_SELECT, event->key.keysym.mod);
+			break;
+		default:
+			break;
 		}
-		else{
-			keystates[key] = PRESSED;
-			onKeyPress(key, event->key.keysym.mod);
-			currentTime = SDL_GetTicks();
-			std::cout << "called onKeyPress" << std::endl;
-		}
-	break;
-	case SDL_KEYUP:
-		std::cout << "KeyUp" << std::endl;
-		keystates[key] = RELEASED;
-		onKeyRelease(key, event->key.keysym.mod);
-		currentTime = SDL_GetTicks();
-		std::cout << "called onKeyRelease" << std::endl;
-	break;
-	default:
-		onUser(event->user.type, event->user.code, event->user.data1, event->user.data2);
-		break;  
+			
 	}
 }
 
-// this will be called when a key is pressed
-// only runs once when the key is pressed
-void PokedexActivityEvent::onKeyPress(SDL_Keycode key, Uint16 mod) {
-	std::cout << "Key: " << key << std::endl;
-	std::cout << "SW_BTN_UP: " << SW_BTN_UP << std::endl;
-	
-	switch(key){
-	case SW_BTN_UP:
-		onButtonUp(key, mod);
-		std::cout << "Called up" << std::endl;
-		break;
-	case SW_BTN_DOWN:
-		onButtonDown(key, mod);
-		std::cout << "Called down" << std::endl;
-		break;
-	case SW_BTN_A:
-		onButtonA(key, mod);
-		std::cout << "Called Button A" << std::endl;
-		break;
-	case SW_BTN_B:
-		onButtonB(key, mod);
-		break;
-	default:
-		break;
+void PokedexActivityEvent::onKeyHold(const Uint8* currentKeyStates, SDL_Event* event) {
+	// D-PAD
+	if (currentKeyStates[SDL_SCANCODE_UP]) {
+		onButtonUp(SW_BTN_UP, event->key.keysym.mod);
+	}
+	if (currentKeyStates[SDL_SCANCODE_DOWN]) {
+		onButtonDown(SW_BTN_DOWN, event->key.keysym.mod);
+	}
+	if (currentKeyStates[SDL_SCANCODE_LEFT]) {
+		onButtonLeft(SW_BTN_LEFT, event->key.keysym.mod);
+	}
+	if (currentKeyStates[SDL_SCANCODE_RIGHT]) {
+		onButtonRight(SW_BTN_RIGHT, event->key.keysym.mod);
 	}
 }
-
-// this will be called when a key is released
-// only runs once when the key is released
-void PokedexActivityEvent::onKeyRelease(SDL_Keycode key, Uint16 mod) {
-    // Exactly when the key is released
-}
-
-// this will be called when a key is held down
-// runs every frame when the key is held down
-// or you can use the timer to check if the key is held down for a certain amount of time
-void PokedexActivityEvent::onKeyHold(SDL_Keycode key, Uint16 mod) {
-	//currentTime = SDL_GetTicks();
-    currentTime = SDL_GetTicks();
-	Uint32 elapsedTime = currentTime - lastTime; 
-	
-	std::cout << "Elapsed Time: " << elapsedTime << std::endl;
-
-	if(elapsedTime >= 100){
-		// examples
-		// A btn run every frame
-		if (key == SW_BTN_UP)
-			onButtonUp(key, mod);
-
-		// examples
-		// A btn run every frame
-		if (key == SW_BTN_DOWN)
-			onButtonDown(key, mod);
-
-		lastTime = currentTime;
-	}
-
-    // examples
-    // A btn run every frame
-    if (key == SW_BTN_A) {
-        // do something
-    }
-
-    // B btn run every other frame
-    if (key == SW_BTN_B) {
-        if (elapsedTime % 2 == 0) {
-            // do something
-        }
-    }
-
-    // X btn run continuously after 500
-    if (key == SW_BTN_X) {
-        if (elapsedTime > 500) {
-            // do something
-        }
-    }
-
-    // Y btn run continously after 1000 but register every 10 frame
-    if (key == SW_BTN_Y) {
-        if (elapsedTime > 1000 && elapsedTime % 10 == 0) {
-            // do something
-        }
-    }
-}
-
 
 void PokedexActivityEvent::onButtonUp(SDL_Keycode sym,Uint16 mod) {
     //Pure virtual, do nothing

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/PokedexActivityEvent.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/PokedexActivityEvent.cc
@@ -13,6 +13,7 @@ void PokedexActivityEvent::onEvent(SDL_Event* event) {
 	}
 	else if (event->type == SDL_KEYDOWN) {
 		switch(event->key.keysym.sym){
+		// DPAD
 		case SW_BTN_UP:
 			onButtonUp(SW_BTN_UP, event->key.keysym.mod);
 			break;
@@ -25,6 +26,7 @@ void PokedexActivityEvent::onEvent(SDL_Event* event) {
 		case SW_BTN_RIGHT:
 			onButtonRight(SW_BTN_RIGHT, event->key.keysym.mod);
 			break;
+		// FACE BUTTON
 		case SW_BTN_A:
 			onButtonA(SW_BTN_A, event->key.keysym.mod);
 			break;
@@ -37,6 +39,20 @@ void PokedexActivityEvent::onEvent(SDL_Event* event) {
 		case SW_BTN_Y:
 			onButtonY(SW_BTN_Y, event->key.keysym.mod);
 			break;
+		// BACK BUTTONS
+		case SW_BTN_R1:
+			onButtonR(SW_BTN_R1, event->key.keysym.mod);
+			break;
+		case SW_BTN_L1:
+			onButtonL(SW_BTN_L1, event->key.keysym.mod);
+			break;
+		case SW_BTN_R2:
+			onButtonRT(SW_BTN_R2, event->key.keysym.mod);
+			break;
+		case SW_BTN_L2:
+			onButtonLT(SW_BTN_L2, event->key.keysym.mod);
+			break;
+		// MENU BUTTONS
 		case SW_BTN_START:
 			onButtonStart(SW_BTN_START, event->key.keysym.mod);
 			break;
@@ -46,7 +62,6 @@ void PokedexActivityEvent::onEvent(SDL_Event* event) {
 		default:
 			break;
 		}
-			
 	}
 }
 

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/PokedexActivityManager.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/PokedexActivityManager.cc
@@ -19,6 +19,12 @@ void PokedexActivityManager::onEvent(SDL_Event* event) {
     }
 }
 
+void PokedexActivityManager::onKeyHold(const Uint8* currentKeyStates, SDL_Event* event) {
+    if (activity) {
+        activity->onKeyHold(currentKeyStates, event);
+    }
+}
+
 void PokedexActivityManager::onLoop() {
     if (activity) {
         activity->onLoop();

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/include/PokedexActivityEvent.h
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/include/PokedexActivityEvent.h
@@ -30,34 +30,16 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
 #include <SDL2/SDL_mixer.h>
-#include <map>
-
-typedef enum {
-	RELEASED,
-	PRESSED,
-	REPEATING
-} KeyStates;
-
-// Would work in SDL1 with SDLKey
-//static KeyStates keystate[320] = {RELEASED};
-static std::map<SDL_Keycode, KeyStates> keystates;
 
 class PokedexActivityEvent {
-private: 
-Uint32 currentTime, lastTime;
-
 public:
     PokedexActivityEvent();
 
     virtual ~PokedexActivityEvent();
 
-	void onKeyPress(SDL_Keycode sym, Uint16 mod);
+    virtual void onEvent(SDL_Event* event);
 
-	void onKeyHold(SDL_Keycode sym, Uint16 mod);
-
-	void onKeyRelease(SDL_Keycode sym, Uint16 mod);
-
-    virtual void onEvent(SDL_Event* Event);
+	void onKeyHold(const Uint8* currentKeyStates, SDL_Event* event);
 
     virtual void onButtonUp(SDL_Keycode sym, Uint16 mod);
 

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/include/PokedexActivityManager.h
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/include/PokedexActivityManager.h
@@ -26,6 +26,8 @@ private:
 public:
     static void onEvent(SDL_Event* Event);
 
+    static void onKeyHold(const Uint8* currentKeyStates, SDL_Event* event);
+
     static void onLoop();
 
     static void onRender(SDL_Surface* surf_display, SDL_Renderer* renderer, SDL_Texture* texture, TTF_Font* font, Mix_Chunk* sEffect);


### PR DESCRIPTION
Smooth Repeat Input.

Lessons Learned:
PC OS handles sending repeat input events. Hence why scanning for keystate isn't required. 

Some devices or libraries, a.k.a Miyoo mini & SDL2, still don't support it the same way OS does under the hood. 

Miyoo doesn't send repeat input, if so, SDL2 lib implementation doesn't handle it. 

Created one switch case to handle initial event, and a separate function in Event manager to scan and handle d-pad button repeat input every 100 milliseconds.  