### PR TITLE
perf: Convert surfaces to RGB565 and optimize text rendering

### DIFF
--- a/Source/union-miyoomini-toolchain/workspace/retrodex/Pokedex.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/Pokedex.cc
@@ -174,7 +174,7 @@ bool Pokedex::onSDLInit()
         exit(EXIT_FAILURE);
     }
 
-    fpsSurface = TTF_RenderUTF8_Blended(font, "0", {0, 128, 0});
+    fpsSurface = TTF_RenderUTF8_Solid(font, "0", {0, 128, 0});
     if (fpsSurface == nullptr)
     {
         std::cout << "Unable to render text! SDL Error: fpsSurface " << TTF_GetError() << std::endl;
@@ -262,7 +262,7 @@ void Pokedex::renderFPS()
             fpsSurface = nullptr;
         }
 
-        fpsSurface = TTF_RenderUTF8_Blended(font, iss.str().c_str(), {0, 128, 0});
+        fpsSurface = TTF_RenderUTF8_Solid(font, iss.str().c_str(), {0, 128, 0});
         if (fpsSurface == nullptr)
         {
             std::cout << "Unable to render text! SDL Error: fpsSurface " << TTF_GetError()

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/intro/PokedexActivityIntro.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/intro/PokedexActivityIntro.cc
@@ -72,7 +72,7 @@ void PokedexActivityIntro::onLoop()
             std::string loadedAssetName = assetManager->getFile().c_str();
             /* std::cout << "Current File: " << assetManager->getFile().c_str() << std::endl; */
 
-            fileSurface = TTF_RenderUTF8_Blended_Wrapped(
+            fileSurface = PokeSurface::renderTextWrappedRGB565(
                 fontSurface, loadedAssetName.c_str(), COLOR, WINDOW_WIDTH);
             if (!fileSurface)
             {

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/menu/render.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/menu/render.cc
@@ -82,7 +82,7 @@ bool PokedexActivityMenu::renderListItems(SDL_Surface *surf_display, int i)
 {
     // List item background
     SDL_Surface *version =
-        TTF_RenderUTF8_Blended(fontSurface, (*dbResults)[offset + i][2].c_str(), COLOR);
+        TTF_RenderUTF8_Solid(fontSurface, (*dbResults)[offset + i][2].c_str(), COLOR);
     if (version == NULL)
     {
         std::cout << "Unable to load surface!"
@@ -91,7 +91,7 @@ bool PokedexActivityMenu::renderListItems(SDL_Surface *surf_display, int i)
     }
 
     SDL_Surface *version_highlight =
-        TTF_RenderUTF8_Blended(fontSurface, (*dbResults)[offset + i][2].c_str(), HIGHLIGHT_COLOR);
+        TTF_RenderUTF8_Solid(fontSurface, (*dbResults)[offset + i][2].c_str(), HIGHLIGHT_COLOR);
     if (version_highlight == NULL)
     {
         std::cout << "Unable to load surface!"

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/pokemons/info/render.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/pokemons/info/render.cc
@@ -69,7 +69,7 @@ bool PokedexActivity_PokemonView_Info::initSDL()
         }
 
         // Pokemon ID
-        id = TTF_RenderUTF8_Blended(fontSurface, pokeID.c_str(), {96, 96, 96});
+        id = TTF_RenderUTF8_Solid(fontSurface, pokeID.c_str(), {96, 96, 96});
         if (!id)
         {
             std::cout << "Unable to load id surface!"
@@ -83,7 +83,7 @@ bool PokedexActivity_PokemonView_Info::initSDL()
 
         // Pokemon Name
         std::string pokeName = pokemon->getName();
-        nameSurface          = TTF_RenderUTF8_Blended(fontSurface, pokeName.c_str(), {96, 96, 96});
+        nameSurface          = TTF_RenderUTF8_Solid(fontSurface, pokeName.c_str(), {96, 96, 96});
         if (!nameSurface)
         {
             std::cout << "Unable to load name surface!"
@@ -99,14 +99,14 @@ bool PokedexActivity_PokemonView_Info::initSDL()
         std::string pokeHeight = pokemon->getHeight();
         std::string pokeWeight = pokemon->getWeight();
 
-        height = TTF_RenderUTF8_Blended(fontSurface, pokeHeight.c_str(), {96, 96, 96});
+        height = TTF_RenderUTF8_Solid(fontSurface, pokeHeight.c_str(), {96, 96, 96});
         if (!height)
         {
             std::cout << "Unable to load height surface!"
                       << " SDL_Error:  " << TTF_GetError();
         };
 
-        weight = TTF_RenderUTF8_Blended(fontSurface, pokeWeight.c_str(), {96, 96, 96});
+        weight = TTF_RenderUTF8_Solid(fontSurface, pokeWeight.c_str(), {96, 96, 96});
         if (weight == NULL)
         {
             std::cout << "Unable to load weight surface!"
@@ -129,7 +129,7 @@ bool PokedexActivity_PokemonView_Info::initSDL()
         iss << (*genderRates)[1] << "/" << (*genderRates)[0];
         std::string genderRatesStr = iss.str();
 
-        gender = TTF_RenderUTF8_Blended(fontSurface, genderRatesStr.c_str(), {96, 96, 96});
+        gender = TTF_RenderUTF8_Solid(fontSurface, genderRatesStr.c_str(), {96, 96, 96});
         if (!gender)
         {
             std::cout << "Unable to load gender surface!"
@@ -143,7 +143,7 @@ bool PokedexActivity_PokemonView_Info::initSDL()
 
         // Pokemon Genus
         std::string pokeGenus = pokemon->getGenus();
-        genus = TTF_RenderUTF8_Blended(fontSurface, pokeGenus.c_str(), {96, 96, 96});
+        genus = TTF_RenderUTF8_Solid(fontSurface, pokeGenus.c_str(), {96, 96, 96});
         if (!genus)
         {
             std::cout << "Unable to load genus surface!"
@@ -158,7 +158,7 @@ bool PokedexActivity_PokemonView_Info::initSDL()
         // Pokemon Flavor Text
         std::string pokeFlavorText = pokemon->getFlavorText();
         flavorText =
-            TTF_RenderUTF8_Blended_Wrapped(fontSurface, pokeFlavorText.c_str(), {96, 96, 96}, 620);
+            PokeSurface::renderTextWrappedRGB565(fontSurface, pokeFlavorText.c_str(), {96, 96, 96}, 620);
         if (flavorText == NULL)
         {
             std::cout << "Unable to load flavorText surface!"

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/pokemons/location/render.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/pokemons/location/render.cc
@@ -53,7 +53,7 @@ bool PokedexActivity_PokemonView_Location::initSDL()
         pokeIconRect.y = 55;
 
         // Pokemon Name
-        pokeName = TTF_RenderUTF8_Blended(fontSurface, pokemon->getName().c_str(), COLOR);
+        pokeName = TTF_RenderUTF8_Solid(fontSurface, pokemon->getName().c_str(), COLOR);
         if (pokeName == NULL)
         {
             throw std::runtime_error(std::string("PokedexActivity_PokemonView_Location::initSDL() "
@@ -203,7 +203,7 @@ bool PokedexActivity_PokemonView_Location::renderItemDetails(SDL_Surface *surf_d
     }
 
     SDL_Surface *detailLocationName =
-        TTF_RenderUTF8_Blended_Wrapped(fontSurface, location.c_str(), COLOR, 295);
+        PokeSurface::renderTextWrappedRGB565(fontSurface, location.c_str(), COLOR, 295);
     if (detailLocationName == NULL)
     {
         std::cerr << "Warning: PokedexActivity_PokemonView_Location::initSDL() Unable to load "
@@ -317,7 +317,7 @@ bool PokedexActivity_PokemonView_Location::renderListItems(SDL_Surface *surf_dis
     {
         locationString[i] = std::toupper(locationString[i]);
     }
-    SDL_Surface *locationName = TTF_RenderUTF8_Blended(fontSurface, locationString.c_str(), COLOR);
+    SDL_Surface *locationName = TTF_RenderUTF8_Solid(fontSurface, locationString.c_str(), COLOR);
     if (locationName == NULL)
     {
         std::cerr << "Warning: PokedexActivity_PokemonView_Location::initSDL() Unable to load "

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/pokemons/moves/render.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/pokemons/moves/render.cc
@@ -52,7 +52,7 @@ bool PokedexActivity_PokemonView_Moves::initSDL()
         pokeIconRect.y = 55;
 
         // Pokemon Name
-        pokeName = TTF_RenderUTF8_Blended(fontSurface, pokemon->getName().c_str(), COLOR);
+        pokeName = TTF_RenderUTF8_Solid(fontSurface, pokemon->getName().c_str(), COLOR);
         if (pokeName == NULL)
         {
             throw std::runtime_error(std::string("PokedexActivity_PokemonView_Moves::initSDL() "
@@ -199,7 +199,7 @@ bool PokedexActivity_PokemonView_Moves::renderListItems(SDL_Surface *surf_displa
     /* PokeSurface::onDrawScaled(surf_display, typeSurface_cache[i + offset], &typeRect); */
 
     // Render Move Name
-    SDL_Surface *moveName = TTF_RenderUTF8_Blended(fontSurface, move[1].c_str(), COLOR);
+    SDL_Surface *moveName = TTF_RenderUTF8_Solid(fontSurface, move[1].c_str(), COLOR);
 
     nameRect = {typeRect.x + typeRect.w + 10, typeRect.y + 5, moveName->w, moveName->h};
     SDL_BlitSurface(moveName, NULL, surf_display, &nameRect);
@@ -215,7 +215,7 @@ bool PokedexActivity_PokemonView_Moves::renderListItems(SDL_Surface *surf_displa
     // Render level
     if (move[9] == "level-up")
     {
-        SDL_Surface *learnLevel = TTF_RenderUTF8_Blended(fontSurface, move[8].c_str(), COLOR);
+        SDL_Surface *learnLevel = TTF_RenderUTF8_Solid(fontSurface, move[8].c_str(), COLOR);
         levelRect               = {methodRect.x + methodRect.w,
                                    (listEntryRect.y + listEntryRect.h) - learnLevel->h,
                                    static_cast<int>(method->w),
@@ -225,7 +225,7 @@ bool PokedexActivity_PokemonView_Moves::renderListItems(SDL_Surface *surf_displa
     }
 
     // Render PP
-    SDL_Surface *pp = TTF_RenderUTF8_Blended(fontSurface, move[3].c_str(), COLOR);
+    SDL_Surface *pp = TTF_RenderUTF8_Solid(fontSurface, move[3].c_str(), COLOR);
     ppRect          = {(listEntryRect.x + listEntryRect.w) - pp->w,
                        (listEntryRect.y + listEntryRect.h) - pp->h,
                        pp->w,
@@ -240,7 +240,7 @@ bool PokedexActivity_PokemonView_Moves::renderItemDetails(SDL_Surface *surf_disp
                                                           int i)
 {
     // Render Power
-    SDL_Surface *power = TTF_RenderUTF8_Blended(fontSurface, move[5].c_str(), COLOR);
+    SDL_Surface *power = TTF_RenderUTF8_Solid(fontSurface, move[5].c_str(), COLOR);
     pwrRect            = {typeARect.x + 40, typeARect.y + 70, power->w, power->h};
 
     SDL_BlitSurface(power, NULL, surf_display, &pwrRect);
@@ -253,7 +253,7 @@ bool PokedexActivity_PokemonView_Moves::renderItemDetails(SDL_Surface *surf_disp
     SDL_BlitSurface(category, NULL, surf_display, &classRect);
 
     // Render Accuracy
-    SDL_Surface *accuracy = TTF_RenderUTF8_Blended(fontSurface, move[6].c_str(), COLOR);
+    SDL_Surface *accuracy = TTF_RenderUTF8_Solid(fontSurface, move[6].c_str(), COLOR);
     accryRect             = {pwrRect.x, (pwrRect.y + pwrRect.h) + 10, accuracy->w, accuracy->h};
 
     SDL_BlitSurface(accuracy, NULL, surf_display, &accryRect);
@@ -261,7 +261,7 @@ bool PokedexActivity_PokemonView_Moves::renderItemDetails(SDL_Surface *surf_disp
     // Render Effect
     std::string summaryText = cleanString((*dbResults)[offset + i][7]);
     SDL_Surface *summary =
-        TTF_RenderUTF8_Blended_Wrapped(fontSurface, summaryText.c_str(), COLOR, 256);
+        PokeSurface::renderTextWrappedRGB565(fontSurface, summaryText.c_str(), COLOR, 256);
     summaryRect = {15, (WINDOW_HEIGHT / 2) + 50, summary->w, summary->h};
 
     SDL_BlitSurface(summary, NULL, surf_display, &summaryRect);

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/pokemons/stats/render.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/pokemons/stats/render.cc
@@ -145,7 +145,7 @@ void PokedexActivity_PokemonView_Stats::onRender(SDL_Surface *surf_display, SDL_
             {
                 std::string ability = (*abilities)[0][0] + "    " + (*abilities)[0][1];
                 abilitySurface =
-                    TTF_RenderUTF8_Blended_Wrapped(fontSurface, ability.c_str(), {96, 96, 96}, 520);
+                    PokeSurface::renderTextWrappedRGB565(fontSurface, ability.c_str(), {96, 96, 96}, 520);
                 if (!abilitySurface)
                 {
                     std::cout << "Unable to load stat surface!"
@@ -163,7 +163,7 @@ void PokedexActivity_PokemonView_Stats::onRender(SDL_Surface *surf_display, SDL_
                 if (abilities->size() > 1)
                 {
                     ability          = (*abilities)[1][0] + "    " + (*abilities)[1][1];
-                    h_abilitySurface = TTF_RenderUTF8_Blended_Wrapped(
+                    h_abilitySurface = PokeSurface::renderTextWrappedRGB565(
                         fontSurface, ability.c_str(), {96, 96, 96}, 620);
                     if (h_abilitySurface == NULL)
                     {

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/setting/render.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/activities/setting/render.cc
@@ -82,7 +82,7 @@ bool PokedexActivitySetting::renderListItems(SDL_Surface *surf_display, TTF_Font
 
         // Render Setting Name
         SDL_Surface *optionNameSurface_selected =
-            TTF_RenderUTF8_Blended(fontSurface, (*settings)[i + offset].c_str(), HIGHLIGHTED_COLOR);
+            TTF_RenderUTF8_Solid(fontSurface, (*settings)[i + offset].c_str(), HIGHLIGHTED_COLOR);
         if (!optionNameSurface_selected)
         {
             std::cerr << "Warning: PokedexActivitySetting::renderListItems() Unable to load "
@@ -106,7 +106,7 @@ bool PokedexActivitySetting::renderListItems(SDL_Surface *surf_display, TTF_Font
 
         // Render Setting Name
         SDL_Surface *optionNameSurface_default =
-            TTF_RenderUTF8_Blended(fontSurface, (*settings)[i + offset].c_str(), COLOR);
+            TTF_RenderUTF8_Solid(fontSurface, (*settings)[i + offset].c_str(), COLOR);
         if (optionNameSurface_default == NULL)
         {
             std::cerr << "Warning: PokedexActivitySetting::renderListItems() Unable to load "
@@ -160,7 +160,7 @@ bool PokedexActivitySetting::renderSettingOptions(SDL_Surface *surf_display, SDL
         if (offset + i == selectedSettingIndex)
         {
             SDL_Surface *settingOptionsSurface_selected =
-                TTF_RenderUTF8_Blended(fontSurface, selectedSetting.c_str(), HIGHLIGHTED_COLOR);
+                TTF_RenderUTF8_Solid(fontSurface, selectedSetting.c_str(), HIGHLIGHTED_COLOR);
             if (settingOptionsSurface_selected == NULL)
             {
                 std::cerr
@@ -180,7 +180,7 @@ bool PokedexActivitySetting::renderSettingOptions(SDL_Surface *surf_display, SDL
         else
         {
             SDL_Surface *settingOptionsSurface_default =
-                TTF_RenderUTF8_Blended(fontSurface, selectedSetting.c_str(), COLOR);
+                TTF_RenderUTF8_Solid(fontSurface, selectedSetting.c_str(), COLOR);
             if (settingOptionsSurface_default == NULL)
             {
                 std::cerr

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/include/PokeSurface.hpp
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/include/PokeSurface.hpp
@@ -3,6 +3,7 @@
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
+#include <SDL2/SDL_ttf.h>
 #include <iostream>
 
 class PokeSurface
@@ -16,6 +17,9 @@ class PokeSurface
     static SDL_Surface *onLoadImg(const std::string &file);
 
     static SDL_Surface* onLoadImgScaled(const std::string &file, int targetW, int targetH);
+
+    static SDL_Surface* renderTextWrappedRGB565(TTF_Font* font, const char* text,
+                                             SDL_Color color, int wrapLength);
 
     static SDL_Surface *onLoadBMP(std::string &file);
 

--- a/Source/union-miyoomini-toolchain/workspace/retrodex/core/utils/PokeSurface.cc
+++ b/Source/union-miyoomini-toolchain/workspace/retrodex/core/utils/PokeSurface.cc
@@ -107,6 +107,25 @@ SDL_Surface* PokeSurface::onLoadImgScaled(const std::string &file, int targetW, 
     return scaled;
 }
 
+SDL_Surface* PokeSurface::renderTextWrappedRGB565(TTF_Font* font, const char* text,
+                                                   SDL_Color color, int wrapLength)
+{
+    // Render with Blended_Wrapped (creates RGBA32)
+    SDL_Surface* blended = TTF_RenderUTF8_Blended_Wrapped(font, text, color, wrapLength);
+    if (!blended) return nullptr;
+    // Create RGB565 surface pre-filled with BLACK (color key)
+    SDL_Surface* rgb565 = SDL_CreateRGBSurfaceWithFormat(
+        0, blended->w, blended->h, 16, SDL_PIXELFORMAT_RGB565);
+    // Use BLACK as background instead of magenta
+    SDL_FillRect(rgb565, NULL, SDL_MapRGB(rgb565->format, 0, 0, 0));
+    
+    SDL_BlitSurface(blended, NULL, rgb565, NULL);
+    SDL_FreeSurface(blended);
+    // Set BLACK as color key
+    SDL_SetColorKey(rgb565, SDL_TRUE, SDL_MapRGB(rgb565->format, 0, 0, 0));
+    return rgb565;
+}
+
 SDL_Surface *PokeSurface::onLoadBMP(std::string &file)
 {
     SDL_Surface *tempSurface      = NULL;


### PR DESCRIPTION
- Convert all image surfaces from RGBA32 to RGB565 format
- Implement magenta color keying for transparency (sprites/icons)
- Change TTF_RenderUTF8_Blended to TTF_RenderUTF8_Solid for most text
- Add PokeSurface::renderTextWrappedRGB565() for wrapped text with black color key
- Refactor AssetManager to delegate surface loading to PokeSurface

Performance improvement: ~47x faster blitting on Miyoo Mini
- Before: 10-20 FPS (BlitNtoNPixelAlpha at 88.76% overhead)
- After: ~50 FPS (BlitRGBto565PixelAlpha at 1.86% overhead)